### PR TITLE
readValue returns avg if enabled

### DIFF
--- a/Libraries/AnalogInput.h
+++ b/Libraries/AnalogInput.h
@@ -49,6 +49,13 @@ public:
   }
 
   int readValue() {
-    return analogRead(analogInputPin);
+    int val;
+    if (enableAverager){
+      val = averager.calculateAverage();
+    }else{
+      val = analogRead(analogInputPin);
+    }
+
+    return val;
   }
 };


### PR DESCRIPTION
minor change, readValue returns avg if enabled.
Should prevent reading "pulses" that don't appear on the graph.