### PR TITLE
remove SerialHOC console logging & set message logging to debug mode …

### DIFF
--- a/ReactSerial/SerialHOC.js
+++ b/ReactSerial/SerialHOC.js
@@ -156,6 +156,8 @@ const withSerialCommunication = (WrappedComponent) => {
             sendData={this.sendData}
             setOnDataCallback={this.setOnDataCallback}
             ipcAvailable={ipcAvailable}
+            startIpcCommunication={this.startIpcCommunication}
+            stopIpcCommunication={this.stopIpcCommunication}
             {...this.props}
           />
           {debugOverlay}
@@ -168,3 +170,4 @@ const withSerialCommunication = (WrappedComponent) => {
 };
 
 export default withSerialCommunication;
+


### PR DESCRIPTION
I took out all console logging (as that's already present in serialRelay.js) and changed `logLine` so that it only actually stores a log if debug mode is enabled. Testing, I found that this version of SerialHOC actually *shrank* slightly in memory usage, whereas the previous version grew at about 3 MB/s.