### PR TITLE
Separating example from gatsby wrapper page.

### DIFF
--- a/ReactSerial/examples/arduino-test-page.js
+++ b/ReactSerial/examples/arduino-test-page.js
@@ -9,11 +9,11 @@ import {
   InputGroup, InputGroupAddon, Button, Input,
 } from 'reactstrap';
 import ReactScrollableList from 'react-scrollable-list';
-import withSerialCommunication from '../Arduino/arduino-base/ReactSerial/SerialHOC';
-import { WAKE_ARDUINO } from '../Arduino/arduino-base/ReactSerial/ArduinoConstants';
-import IPC from '../Arduino/arduino-base/ReactSerial/IPCMessages';
+import withSerialCommunication from '../SerialHOC';
+import { WAKE_ARDUINO } from '../ArduinoConstants';
+import IPC from '../IPCMessages';
 
-class ArduinoPage extends Component {
+class ArduinoTestPage extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -168,6 +168,6 @@ class ArduinoPage extends Component {
   }
 }
 
-const ArduinoPageWithSerialCommunication = withSerialCommunication(ArduinoPage);
+const ArduinoTestPageWithSerialCommunication = withSerialCommunication(ArduinoTestPage);
 
-export default ArduinoPageWithSerialCommunication;
+export default ArduinoTestPageWithSerialCommunication;

--- a/ReactSerial/examples/gatsby/gatsby-wrapper-page.js
+++ b/ReactSerial/examples/gatsby/gatsby-wrapper-page.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import ArduinoTestPage from '../Arduino/arduino-base/ReactSerial/examples/arduino-test-page';
+
+const ArduinoWrapperPage = () => (
+  <ArduinoTestPage />
+);
+
+export default ArduinoWrapperPage;


### PR DESCRIPTION
This is part of a proposed solution being discussed here:
https://github.com/scimusmn/app-template/pull/3#issuecomment-738838170

Only merge this if we go forward with that strategy. Once merged, the following command should be appended to the `app-template` `install-arduino-base` script:

```bash
// Copy wrapper page into Gatsby pages directory
execSync('cp src/Arduino/arduino-base/ReactSerial/examples/gatsby/gatsby-wrapper-page.js src/pages/arduino.js');
```