### PR TITLE
Button library improvements

### DIFF
--- a/Libraries/Button.h
+++ b/Libraries/Button.h
@@ -16,9 +16,7 @@ public:
   int debounce;
   void (*callback)(int buttonState);
 
-  Button() {}
-
-  void setup(int p, void (*CB)(int))
+  Button(int p, void (*CB)(int)) //pin, callback
   {
     callback = CB;
     pin = p;

--- a/Libraries/Button.h
+++ b/Libraries/Button.h
@@ -8,13 +8,13 @@ class Button
 {
 private:
   int pin;
-  bool reading;
-  unsigned long lastReadingChangeMillis;
+  bool lastPinState;
+  unsigned long pinChangeMillis;
 
 public:
-  bool state;
+  bool buttonState;
   int debounce;
-  void (*callback)(int state);
+  void (*callback)(int buttonState);
 
   Button() {}
 
@@ -24,21 +24,24 @@ public:
     pin = p;
     pinMode(p, INPUT_PULLUP);
     debounce = 20;
-    state = (digitalRead(pin));
+    lastPinState = buttonState = (digitalRead(pin));
   }
 
   void update()
   {
-    if (digitalRead(pin) != reading)
+    bool pinState = digitalRead(pin);
+
+    //if the state of the pin has changed.
+    if (pinState != lastPinState)
     {
-      reading = !reading;
-      lastReadingChangeMillis = millis();
+      lastPinState = pinState;
+      pinChangeMillis = millis();
     }
 
-    if (((millis() - lastReadingChangeMillis) > debounce) && state != reading)
+    if (((millis() - pinChangeMillis) > debounce) && buttonState != pinState)
     {
-      state = reading;
-      callback(!state);
+      buttonState = pinState;
+      callback(!buttonState);
     }
   }
 };

--- a/Libraries/Button.h
+++ b/Libraries/Button.h
@@ -43,6 +43,7 @@ public:
       pinChangeMillis = millis();
     }
 
+    //if the pin state was stable for the debounce value in millis.
     if (((millis() - pinChangeMillis) > debounce) && buttonState != pinState)
     {
       buttonState = pinState;

--- a/Libraries/Button.h
+++ b/Libraries/Button.h
@@ -9,23 +9,30 @@ class Button
 private:
   int pin;
   bool lastPinState;
-  unsigned long pinChangeMillis;
-
-public:
-  bool buttonState;
   int debounce;
+  unsigned long pinChangeMillis;
+  bool buttonState;
   void (*callback)(int);
 
-  Button(int p, void (*CB)(int)) //pin, callback
+public:
+  // constructor (pin, callback function, [optional] debounce in millis)
+  Button(int p, void (*CB)(int), int _debounce = 20)
   {
     callback = CB;
     pin = p;
     pinMode(p, INPUT_PULLUP);
-    debounce = 20;
+    debounce = _debounce;
     lastPinState = buttonState = (digitalRead(pin));
   }
 
-  void update()
+  // returns the button state
+  bool getState()
+  {
+    return buttonState;
+  }
+
+  //run in a loop when button press should be noticed.
+  void listener()
   {
     bool pinState = digitalRead(pin);
 

--- a/Libraries/Button.h
+++ b/Libraries/Button.h
@@ -4,8 +4,7 @@
 #ifndef Button_h
 #define Button_h
 
-class Button
-{
+class Button {
 private:
   int pin;
   bool lastPinState;
@@ -16,8 +15,7 @@ private:
 
 public:
   // constructor (pin, callback function, [optional] debounce in millis)
-  Button(int p, void (*CB)(int), int _debounce = 20)
-  {
+  Button(int p, void (*CB)(int), int _debounce = 20) {
     callback = CB;
     pin = p;
     pinMode(p, INPUT_PULLUP);
@@ -26,26 +24,22 @@ public:
   }
 
   // returns the button state
-  bool getState()
-  {
+  bool getState() {
     return buttonState;
   }
 
   //run in a loop when button press should be noticed.
-  void listener()
-  {
+  void update() {
     bool pinState = digitalRead(pin);
 
     //if the state of the pin has changed.
-    if (pinState != lastPinState)
-    {
+    if (pinState != lastPinState) {
       lastPinState = pinState;
       pinChangeMillis = millis();
     }
 
     //if the pin state was stable for the debounce value in millis.
-    if (((millis() - pinChangeMillis) > debounce) && buttonState != pinState)
-    {
+    if (((millis() - pinChangeMillis) > debounce) && buttonState != pinState) {
       buttonState = pinState;
       callback(!buttonState);
     }

--- a/Libraries/Button.h
+++ b/Libraries/Button.h
@@ -4,36 +4,40 @@
 #ifndef Button_h
 #define Button_h
 
-class Button {
+class Button
+{
+private:
+  int pin;
+  bool reading;
+  unsigned long lastReadingChangeMillis;
+
 public:
   bool state;
-  bool fired;
-  bool lastFired;
-  unsigned long debounceTimer;
   int debounce;
-  int pin;
   void (*callback)(int state);
 
   Button() {}
 
-  void setup(int p, void (*CB)(int)) {
+  void setup(int p, void (*CB)(int))
+  {
     callback = CB;
     pin = p;
     pinMode(p, INPUT_PULLUP);
-    debounceTimer = 0;
     debounce = 20;
-    lastFired = state = fired = true;
+    state = (digitalRead(pin));
   }
 
-  void update() {
-    if (digitalRead(pin) != state) {
-      state = !state;
-      fired = !state;
-      debounceTimer = millis() + debounce;
+  void update()
+  {
+    if (digitalRead(pin) != reading)
+    {
+      reading = !reading;
+      lastReadingChangeMillis = millis();
     }
 
-    if (debounceTimer < millis() && state != fired && lastFired != state) {
-      lastFired = fired = state;
+    if (((millis() - lastReadingChangeMillis) > debounce) && state != reading)
+    {
+      state = reading;
       callback(!state);
     }
   }

--- a/Libraries/Button.h
+++ b/Libraries/Button.h
@@ -14,7 +14,7 @@ private:
 public:
   bool buttonState;
   int debounce;
-  void (*callback)(int buttonState);
+  void (*callback)(int);
 
   Button(int p, void (*CB)(int)) //pin, callback
   {

--- a/README.md
+++ b/README.md
@@ -165,29 +165,10 @@ To setup a new `Button`, you'll need to pass in two parameters:
 
 1. `int` pin, location of the input pin
 2. `void (*callback)(int)`, a callback function that accepts the returned `int` value of the sensor
+3. (optional) `int` debounce value in milliseconds.
 
 #### Button Example
-```
-#include "Libraries/Button.h"
-
-Button button1;
-int button1Pin = 2;
-
-void setup() {
-
-  button1.setup(button1Pin, [](int state) {
-    if (state == 1) {
-      // This means, our button was pressed
-      // We should do something, like turn on a light
-    }
-  });
-
-}
-
-void loop() {
-  button1.update();
-}
-```
+See Examples Folder
 
 ### Timer.h
 This library is used to handle common timer-related functions. Currently, it does timing by counting from `millis()` although, in the future, `micros()` may be implemented.

--- a/examples/Button/Button.ino
+++ b/examples/Button/Button.ino
@@ -4,9 +4,10 @@
 
 #include "C:\Users\jmeyer\Documents\Code\arduino-base\Libraries\Button.h"
 
+//declare pin assignments at the top as constant integers
 const int buttonPin = 4;
 
-Button myButton(buttonPin, &buttonFunction);
+Button myButton(buttonPin, &buttonFunction, 30); // pin, function reference, (optional)debounce in milliseconds.
 
 void setup()
 {
@@ -16,7 +17,7 @@ void setup()
 
 void loop()
 {
-  myButton.update();
+  myButton.listener();
 }
 
 void buttonFunction(int state)

--- a/examples/Button/Button.ino
+++ b/examples/Button/Button.ino
@@ -8,19 +8,16 @@ const int buttonPin = 4;
 
 Button myButton(buttonPin, &buttonFunction, 30); // pin, function reference, (optional)debounce in milliseconds.
 
-void setup()
-{
+void setup() {
   Serial.begin(9600);
   pinMode(LED_BUILTIN, OUTPUT);
 }
 
-void loop()
-{
-  myButton.listener();
+void loop() {
+  myButton.update();
 }
 
-void buttonFunction(int state)
-{
+void buttonFunction(int state) {
   //replace with code to execute based on button state.
   digitalWrite(LED_BUILTIN, state);
   if (state == 1)

--- a/examples/Button/Button.ino
+++ b/examples/Button/Button.ino
@@ -1,7 +1,6 @@
-// To get this sketch to compile
-// you must update this library with your own absolute path
 // Arduino does not support relative paths :(
-
+// To get this sketch to compile, you must update this include
+// statement with your own absolute path to the library
 #include "C:\Users\jmeyer\Documents\Code\arduino-base\Libraries\Button.h"
 
 //declare pin assignments at the top as constant integers

--- a/examples/Button/Button.ino
+++ b/examples/Button/Button.ino
@@ -4,17 +4,25 @@
 
 #include "C:\Users\jmeyer\Documents\Code\arduino-base\Libraries\Button.h"
 
-int button1Pin = 2;
-Button button1(button1Pin, [](int state) {
-  digitalWrite(LED_BUILTIN, state);
-});
+const int buttonPin = 4;
+
+Button myButton(buttonPin, &buttonFunction);
 
 void setup()
 {
+  Serial.begin(9600);
   pinMode(LED_BUILTIN, OUTPUT);
 }
 
 void loop()
 {
-  button1.update();
+  myButton.update();
+}
+
+void buttonFunction(int state)
+{
+  //replace with code to execute based on button state.
+  digitalWrite(LED_BUILTIN, state);
+  if (state == 1)
+    Serial.println("Button pressed");
 }

--- a/examples/Button/Button.ino
+++ b/examples/Button/Button.ino
@@ -1,0 +1,20 @@
+// To get this sketch to compile
+// you must update this library with your own absolute path
+// Arduino does not support relative paths :(
+
+#include "C:\Users\jmeyer\Documents\Code\arduino-base\Libraries\Button.h"
+
+int button1Pin = 2;
+Button button1(button1Pin, [](int state) {
+  digitalWrite(LED_BUILTIN, state);
+});
+
+void setup()
+{
+  pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop()
+{
+  button1.update();
+}


### PR DESCRIPTION
## Readability
I had a hard time following how this worked so...
- variables were renamed
- logic was simplified
- comments were added

## update() renamed to listener()
This may be pedantic (but most of programming is?) and I know we already changed it once.
We are not "updating" the button, we are adding a "listener" to a loop in our sketch.
If this is the only thing you're hung up on, I can revert this change.

## Removed setup() in favor of doing button setup in the constructor
Previously this was an empty constructor and one would run setup(pin,callback,etc) in the arduino sketch setup function.
I think there are advantages to getting rid of the setup function.
- declare and define the button right at the top of your sketch.
- declutter the sketch's setup function
- modify fewer lines of code to add/remove buttons from a sketch.

## An example sketch
Examples>Button>Button.ino
I put a button example sketch in the example folder with my current understanding of best practices.
I updated the readMe file accordingly.
Since Arduino doesn't allow for relative library paths in the include statements, this must be modified to compile. :(
**_note:_** pass in a pointer to a function rather than putting a bunch of code in the button constructor (formerly in the sketch's setup function)!

## Private variables
All variables were public, which I believe enables some bad coding practices.
If you want to know the state of the button use the function getState().  If you can see a reason to access the other variables involved please let me know and give an example.